### PR TITLE
Fix error if Content-Length has already been set

### DIFF
--- a/src/Webpack/WebpackMiddleware.cs
+++ b/src/Webpack/WebpackMiddleware.cs
@@ -48,7 +48,7 @@ namespace Webpack {
 						writer.Write(response);
 						writer.Flush();
 						memStream.Seek(0, SeekOrigin.Begin);
-						context.Response.Headers.Add("Content-Length", memStream.Length.ToString());
+						context.Response.Headers["Content-Length"] = memStream.Length.ToString();
 						await memStream.CopyToAsync(stream);
 					}
 				}


### PR DESCRIPTION
Change fixes an error if the Content-Length property has already been set.  By using the array access operator, it doesn't matter if the Content-Length exists in the dictionary or not.
