### PR TITLE
Allow using just a config and Webpack options.

### DIFF
--- a/Aspnet.Webpack.sln
+++ b/Aspnet.Webpack.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DFEA8E27-FC5E-4629-BCCF-6FB4A8571CBB}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Webpack/Extensions/DevToolTypeExtensions.cs
+++ b/src/Webpack/Extensions/DevToolTypeExtensions.cs
@@ -22,8 +22,11 @@
 					return "eval-source-map";
 				case DevToolType.SourceMap:
 					return "source-map";
+			    case DevToolType.CheapModuleSourceMap:
+					return "cheap-module-source-map";
+                default:
+					return "source-map";
 			}
-			return "source-map";
 		}
 	}
 }

--- a/src/Webpack/IWebpack.cs
+++ b/src/Webpack/IWebpack.cs
@@ -18,5 +18,13 @@ namespace Webpack {
 		/// <param name="outputFileName">The name of the output file</param>
 		/// <param name="devServerOptions">The dev server options in case we need hot loading</param>
 		WebPackMiddlewareOptions Execute(string configFile, string outputFileName, WebpackDevServerOptions devServerOptions);
-	}
+
+        /// <summary>
+        /// Executes the webpack or webpack-dev-server based on an external configuration file.
+        /// </summary>
+        /// <param name="configFile"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        WebPackMiddlewareOptions Execute(string configFile, WebpackOptions options);
+    }
 }

--- a/src/Webpack/WebPackMiddlewareOptions.cs
+++ b/src/Webpack/WebPackMiddlewareOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Webpack {
+﻿using System.Collections.Generic;
+
+namespace Webpack {
 
 	/// <summary>
 	/// The required options for the middleware in order to add the appropriate script tags
@@ -10,18 +12,18 @@
 		/// </summary>
 		public bool EnableHotLoading { get; set; }
 
-		/// <summary>
-		/// The file name of the output bundle
-		/// In order to put the file in a different folder use a relative path e.g. js/webpackBundle.js
-		/// If not specified is "bundle.js"
-		/// </summary>
-		public string OutputFileName { get; set; }
+        /// <summary>
+        /// The file names of the output bundles
+        /// In order to put the file in a different folder use a relative path e.g. js/webpackBundle.js
+        /// If not specified, a single bundle is used "bundle.js"
+        /// </summary>
+        public IEnumerable<string> OutputFileNames { get; set; }
 
-		/// <summary>
-		/// The ip address of the server
-		/// Default value if not specified is localhost
-		/// </summary>
-		public string Host { get; set; }
+        /// <summary>
+        /// The ip address of the server
+        /// Default value if not specified is localhost
+        /// </summary>
+        public string Host { get; set; }
 
 		/// <summary>
 		/// The port of the server

--- a/src/Webpack/WebpackExtenstions.cs
+++ b/src/Webpack/WebpackExtenstions.cs
@@ -20,48 +20,50 @@ namespace Webpack {
 			return app;
 		}
 
-		/// <summary>
-		/// Adds webpack functionality to the application. It should be used only in development environment.
-		/// This method is used when hot loading is not necessary and we need from webpack just to create the bundles.
-		/// The <paramref name="outputFileName"/> is required for the underlying middleware to add the appropriate script tag
-		/// </summary>
-		/// <param name="configFile">The path to the external configuration file e.g. webpack/webpack.development.js</param>
-		/// <param name="outputFileName">
-		/// The file name of the output bundle
-		/// This value must be the same as the one in external configuration file output section
-		/// output: {
-		///	  filename: 'bundle.js',
-		///	},
-		/// </param>
-		public static IApplicationBuilder UseWebpack(this IApplicationBuilder app, string configFile, string outputFileName) {
+	    ///  <summary>
+	    ///  Adds webpack functionality to the application. It should be used only in development environment.
+	    ///  This method is used when hot loading is not necessary and we need from webpack just to create the bundles.
+	    ///  The <paramref name="outputFileName"/> is required for the underlying middleware to add the appropriate script tag
+	    ///  </summary>
+	    /// <param name="app"></param>
+	    /// <param name="configFile">The path to the external configuration file e.g. webpack/webpack.development.js</param>
+	    ///  <param name="outputFileName">
+	    ///  The file name of the output bundle
+	    ///  This value must be the same as the one in external configuration file output section
+	    ///  output: {
+	    /// 	  filename: 'bundle.js',
+	    /// 	},
+	    ///  </param>
+	    public static IApplicationBuilder UseWebpack(this IApplicationBuilder app, string configFile, string outputFileName) {
 			var webpack = app.ApplicationServices.GetService<IWebpack>();
 			var middleWareOptions = webpack.Execute(configFile, outputFileName, null);
 			app.UseMiddleware<WebpackMiddleware>(middleWareOptions);
 			return app;
 		}
 
-		/// <summary>
-		/// Adds webpack functionality to the application. It should be used only in development environment.
-		/// This method is used when we need to enable hot loading.
-		/// The <paramref name="outputFileName"/> and <paramref name="devServerOptions"/> are required for the underlying middleware to add the appropriate script tag
-		/// </summary>
-		/// <param name="configFile">The path to the external configuration file e.g. webpack/webpack.development.js</param>
-		/// <param name="outputFileName">
-		/// The file name of the output bundle
-		/// This value must be the same as the one in external configuration file output section
-		/// output: {
-		///	  filename: 'bundle.js',
-		///	},
-		/// </param>
-		/// <param name="devServerOptions">
-		/// The development server configuration options
-		/// These values should be the same as the ones in external configuration file devserver section
-		/// devServer: {
-		///   host: "0.0.0.0",
-		///   port: "3000",
-		/// },
-		/// </param>
-		public static IApplicationBuilder UseWebpack(
+	    ///  <summary>
+	    ///  Adds webpack functionality to the application. It should be used only in development environment.
+	    ///  This method is used when we need to enable hot loading.
+	    ///  The <paramref name="outputFileName"/> and <paramref name="devServerOptions"/> are required for the underlying middleware to add the appropriate script tag
+	    ///  </summary>
+	    /// <param name="app"></param>
+	    /// <param name="configFile">The path to the external configuration file e.g. webpack/webpack.development.js</param>
+	    ///  <param name="outputFileName">
+	    ///  The file name of the output bundle
+	    ///  This value must be the same as the one in external configuration file output section
+	    ///  output: {
+	    /// 	  filename: 'bundle.js',
+	    /// 	},
+	    ///  </param>
+	    ///  <param name="devServerOptions">
+	    ///  The development server configuration options
+	    ///  These values should be the same as the ones in external configuration file devserver section
+	    ///  devServer: {
+	    ///    host: "0.0.0.0",
+	    ///    port: "3000",
+	    ///  },
+	    ///  </param>
+	    public static IApplicationBuilder UseWebpack(
 			this IApplicationBuilder app,
 			string configFile,
 			string outputFileName,
@@ -71,5 +73,23 @@ namespace Webpack {
 			app.UseMiddleware<WebpackMiddleware>(options);
 			return app;
 		}
-	}
+
+        /// <summary>
+        /// Adds webpack functionality to the application. It should be used only in development environment.
+		/// This method requires an external configuration file and covers specific configurations based on an external config file.
+		/// Based on the provided <paramref name="webpackOptions"/> the underlying middleware will add the required script tags
+		/// so there is not need to add them manually.
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="configFile">The path to the external configuration file e.g. webpack/webpack.development.js</param>
+        /// <param name="webpackOptions">Configuration options which sets flags on the webpack command and adds the required script tags.</param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseWebpack(this IApplicationBuilder app, string configFile, WebpackOptions webpackOptions)
+        {
+            var webpack = app.ApplicationServices.GetService<IWebpack>();
+            var options = webpack.Execute(configFile, webpackOptions);
+            app.UseMiddleware<WebpackMiddleware>(options);
+            return app;
+        }
+    }
 }

--- a/src/Webpack/WebpackOptions.cs
+++ b/src/Webpack/WebpackOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Webpack {
 
@@ -8,31 +9,35 @@ namespace Webpack {
 	/// </summary>
 	public class WebpackOptions {
 
-		public WebpackOptions(
-			string entryPoint = "app/index.js",
-			string outputFileName = "bundle.js",
-			bool handleStyles = true) {
+		public WebpackOptions(string entryPoint = "app/index.js", string outputFileName = "bundle.js", bool handleStyles = true) {
 			EntryPoint = entryPoint;
-			OutputFileName = outputFileName;
 			DevToolType = DevToolType.SourceMap;
 			EnableES2015 = true;
 			HandleStyles = handleStyles;
 			DevServerOptions = new WebpackDevServerOptions();
 			StylesTypes = new List<StylesType>();
 			StaticFileTypes = new List<StaticFileType>();
-		}
+            OutputFileName = outputFileName;
+        }
 
-		/// <summary>
-		/// The relative path to applications root
-		/// </summary>
-		public string EntryPoint { get; set; }
+        /// <summary>
+        /// The relative path to applications root
+        /// </summary>
+        public string EntryPoint { get; set; }
 
-		/// <summary>
-		/// The file name of the output bundle
-		/// In order to put the file in a different folder use a relative path e.g. js/webpackBundle.js
-		/// If not specified is "bundle.js"
-		/// </summary>
-		public string OutputFileName { get; set; }
+        /// <summary>
+        /// The file name of a single output bundle
+        /// In order to put the file in a different folder use a relative path e.g. js/webpackBundle.js
+        /// If not specified is "bundle.js"
+        /// </summary>
+        public string OutputFileName { get; set; }
+
+        /// <summary>
+        /// The file names of the output bundles
+        /// In order to put the files in a different folder use a relative path(s) e.g. js/webpackBundle.js
+        /// If not specified, as single bundle, "bundle.js", is used
+        /// </summary>
+        public IEnumerable<string> OutputFileNames { get; set; }
 
 		/// <summary>
 		/// Indicates the type of the development tool will be used by webpack. See http://webpack.github.io/docs/configuration.html#devtool
@@ -68,12 +73,18 @@ namespace Webpack {
 		/// </summary>
 		public bool HandleAngularTemplates { get; set; }
 
-		/// <summary>
-		/// Indicates if webpack should handle the static file types through URL and file loader
-		/// </summary>
-		public bool HandleStaticFiles { get; set; }
+        /// <summary>
+        /// Indicates if webpack should handle the static file types through URL and file loader
+        /// https://webpack.github.io/docs/hot-module-replacement.html
+        /// </summary>
+        public bool HandleStaticFiles { get; set; }
 
-		/// <summary>
+        /// <summary>
+        /// Indicates hot module replacement should be enabled
+        /// </summary>
+	    public bool EnableHotModuleReplacement { get; set; }
+
+	    /// <summary>
 		/// Indicates the limit of the file size in bytes to use with URL loader
 		/// When a file exceeds that limit it will be handled by file loader
 		/// https://github.com/webpack/url-loader
@@ -94,6 +105,28 @@ namespace Webpack {
 		/// The development server configuration options
 		/// </summary>
 		public WebpackDevServerOptions DevServerOptions { get; set; }
+
+        /// <summary>
+        /// Indicates if there are multiple bundles set
+        /// </summary>
+	    public bool HasMultipleBundles()
+        {
+            return OutputFileNames != null && OutputFileNames.Any();
+        }
+
+	    public List<string> GetBundlesList()
+	    {
+            List<string> outputNames;
+            if (!HasMultipleBundles())
+            {
+                outputNames = new List<string> { OutputFileName };
+            }
+            else
+            {
+                outputNames = OutputFileNames as List<string>;
+            }
+	        return outputNames;
+	    }
 	}
 
 	public enum StylesType {

--- a/src/Webpack/project.json
+++ b/src/Webpack/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.0.0",
+  "version": "3.1.1",
   "title": "Webpack",
   "description": "Webpack extension methods and middleware for using module bundling in an ASP.NET Core applications",
   "authors": [ "Charalampos Karypidis" ],


### PR DESCRIPTION
Added new using middleware and execute to allow setting up webpack with just a webpack config file and availability of the Webpack options.

Add option to insert multiple bundles into the HTML and option allow for enabling Hot Module Replacement.
